### PR TITLE
Remove exclude files from Packages.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,6 @@ let package = Package(
     .library(name: "cmark_gfm", targets: ["cmark_gfm"])
   ],
   targets: [
-    .target(name: "cmark_gfm", path: "Sources", exclude: ["main.c"]),
+    .target(name: "cmark_gfm", path: "Sources"),
   ]
 )


### PR DESCRIPTION
The main.c file doesn't exist in the fork and it makes Xcode raise a warning in compile time.